### PR TITLE
Avoid empty logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,36 +5,36 @@ var execFile = require('child_process').execFile;
 
 module.exports = function (options) {
 
-    var nugetPath =  __dirname + "./nuget.exe";
-    var monoPath  =  null;
+    var nugetPath = __dirname + "./nuget.exe";
+    var monoPath = null;
     var targetFile = nugetPath;
     var cmdArgs = ["restore"];
 
-    if(options){
+    if (options) {
         nugetPath = options.nugetPath || nugetPath;
         monoPath = options.monoPath || monoPath;
-        if(options.additionalArgs && options.additionalArgs.length > 0){
-        cmdArgs =  cmdArgs.concat(options.additionalArgs);
+        if (options.additionalArgs && options.additionalArgs.length > 0) {
+            cmdArgs = cmdArgs.concat(options.additionalArgs);
         }
     }
-     if(monoPath && monoPath.length > 0){
+    if (monoPath && monoPath.length > 0) {
         targetFile = monoPath;
         cmdArgs.unshift(nugetPath);
     }
-	return through.obj(function (file, enc, cb) {
-		if (!file || !file.path) {
-			cb(null, file);
-			return;
-		}
+
+    return through.obj(function (file, enc, cb) {
+        if (!file || !file.path) {
+            cb(null, file);
+            return;
+        }
         cmdArgs.push(file.path);
-        return execFile(targetFile, cmdArgs, function(error, stdout, stderror){
-             console.log(stdout);
-            console.log(stderror);
-             if (error) {
+        return execFile(targetFile, cmdArgs, function (error, stdout, stderror) {
+            if (stdout.trim()) gutil.log(stdout);
+            if (stderror.trim()) gutil.log(stderror);
+            if (error) {
                 throw error;
             }
             cb(null, file);
         });
-
-	});
+    });
 };


### PR DESCRIPTION
- Avoid useless empty logging when stdout/stderr is empty. Using gutil.log instead of console.log.
- Formatting code
