### PR TITLE
Enabled support for multiple sln files

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ module.exports = function (options) {
             cb(null, file);
             return;
         }
-        cmdArgs.push(file.path);
-        return execFile(targetFile, cmdArgs, function (error, stdout, stderror) {
+        var localArgs = cmdArgs.concat(file.path);
+        return execFile(targetFile, localArgs, function (error, stdout, stderror) {
             if (stdout.trim()) {
               gutil.log(stdout);
             }


### PR DESCRIPTION
Fixed bug where each additional piped file would add to the list of parameters for the nuget restore call. Each file is now added to a local array instead of pushing to a global array.