### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var through = require('through2');
 var execFile = require('child_process').execFile;
 
@@ -30,10 +30,10 @@ module.exports = function (options) {
         cmdArgs.push(file.path);
         return execFile(targetFile, cmdArgs, function (error, stdout, stderror) {
             if (stdout.trim()) {
-              gutil.log(stdout);
+              log(stdout);
             }
             if (stderror.trim()){
-              gutil.log(stderror);
+              log(stderror);
             }
             if (error) {
                 throw error;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.1",
+    "fancy-log": "^1.3.2",
     "through2": "^0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
gulp-util is deprecated: https://www.npmjs.com/package/gulp-util
Replaced with fancy-log